### PR TITLE
Possible bug - detecting if min already reached

### DIFF
--- a/2_optimisation_and_probability.Rmd
+++ b/2_optimisation_and_probability.Rmd
@@ -229,14 +229,21 @@ lm_gd<-function(x, # vector of x values
       # Step 3: update m according to m = m-L*D_m
       m[i+1,1] <- m[i,1]-step.size*d_m[i,1]
     
-      if(i>1 & all(abs(d_m)< changes)){
+      if(i>1 & abs(d_m[i,1])< changes){
         i=i-1
         break;
       }
     }
 
+      
+  iterations_to_return <- min(i+1, max.iter)
+  # print(paste("Iterations to return: ", iterations_to_return))
   # Return results
-  gd_output <- data.frame("i" = seq(1:max.iter), "m" = m, "d_m" = d_m)
+  gd_output <- data.frame(
+    "i" = seq(1:iterations_to_return), 
+    "m" = head(m, iterations_to_return), 
+    "d_m" = head(d_m, iterations_to_return)
+  )
   return(gd_output)
 }
 


### PR DESCRIPTION
I think the current code for `lm_gd` continues till `max.iter` even if minimum value of `d_m` is reached. 
- The current code attempts to ensure that *all* of d_m are less than *changes* however, (I think) we only need to ensure the current value given by d_m[i,1] is less than *changes*
- iterations_to_return calculates the number of iterations to return, this would be equal to max.iter if convergence is not reached and iterations are exhausted, otherwise it would be equal to the iteration at which convergence is reached as per *changes* value
- head() is used to "cut" the extra 0 rows in m, d_m